### PR TITLE
Fix false positive when the clicked element is removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ exports = module.exports = {
       var elements = e.path || (e.composedPath && e.composedPath())
       elements && elements.length > 0 && elements.unshift(e.target)
 
-      if (el.contains(e.target) || isPopup(vNode.context.popupItem, elements)) return
+      if (el.contains(e.target) || elements.indexOf(el) !== -1 || isPopup(vNode.context.popupItem, elements)) return
 
       el.__vueClickOutside__.callback(e)
     }


### PR DESCRIPTION
When the click deletes the clicked element, the callback fires, even if the clicked element was the main element's children.

This can be fixed by checking the click event path for the main element, like they do in https://github.com/ndelvalle/v-click-outside/blob/master/src/v-click-outside.js